### PR TITLE
Add the ability to specify a timestamp for Solver.solve

### DIFF
--- a/lib/pow.d.ts
+++ b/lib/pow.d.ts
@@ -1,7 +1,11 @@
 import { Buffer } from 'buffer';
 
+export interface ISolveOptions {
+  timestamp: number;
+}
+
 export class Solver {
-  public solve(complexity: number, prefix?: Buffer): Buffer;
+  public solve(complexity: number, prefix?: Buffer, opts?: ISolveOptions): Buffer;
 }
 
 export interface IVerifierOptions {

--- a/lib/pow/solver.js
+++ b/lib/pow/solver.js
@@ -10,10 +10,8 @@ function Solver() {
 }
 module.exports = Solver;
 
-Solver.prototype._genNonce = function _genNonce(buf) {
-  const now = Date.now();
-
-  let off = utils.writeTimestamp(buf, now, 0);
+Solver.prototype._genNonce = function _genNonce(buf, timestamp) {
+  let off = utils.writeTimestamp(buf, timestamp, 0);
   const words = off + (((buf.length - off) / 4) | 0) * 4;
 
   // Fast writes
@@ -25,13 +23,26 @@ Solver.prototype._genNonce = function _genNonce(buf) {
     buf[off] = (Math.random() * 0x100) >>> 0;
 };
 
-Solver.prototype.solve = function solve(complexity, prefix) {
+Solver.prototype.solve = function solve(complexity, prefix, opts) {
+  const start = Date.now();
+
+  if (opts == null) {
+    opts = {};
+  }
+
   // 64 bits of entropy should be enough for each millisecond to avoid
   // collisions
   const nonce = utils.allocBuffer(NONCE_SIZE);
 
   for (;;) {
-    this._genNonce(nonce);
+    let timestamp;
+    if (opts.timestamp) {
+      timestamp = opts.timestamp + (Date.now() - start);
+    } else {
+      timestamp = Date.now();
+    }
+
+    this._genNonce(nonce, timestamp);
 
     const hash = utils.hash(nonce, prefix);
 


### PR DESCRIPTION
This is useful when you don't want to rely on the users local clock
being synchornized with the server.